### PR TITLE
bump pandoc types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export let PANDOC_API_VERSION = [1, 22, 2];
+export let PANDOC_API_VERSION = [1, 22, 2, 1];
 
 export const setPandocApiVersion = (version) => {
     PANDOC_API_VERSION = version;


### PR DESCRIPTION
Bumps pandoc types from 1.22.2 -> 1.22.2.1 to match bumping pandoc in pubpub to 2.19.2

Should be no breaking changes in the bump: https://github.com/jgm/pandoc-types/commit/da9aeed5f3c5e7ad4d456e5b1e99e7a1573854be